### PR TITLE
use custom tag instead of native getTag()

### DIFF
--- a/bottomdialog/src/main/java/me/shaohui/bottomdialog/BottomDialog.java
+++ b/bottomdialog/src/main/java/me/shaohui/bottomdialog/BottomDialog.java
@@ -130,7 +130,7 @@ public class BottomDialog extends BaseBottomDialog {
     }
 
     public BaseBottomDialog show() {
-        show(mFragmentManager, getTag());
+        show(mFragmentManager);
         return this;
     }
 }


### PR DESCRIPTION
Now method `show()` in 'BottomDialog' use the native 'getTag()' instead of our custom tag. That's not our wish~
